### PR TITLE
Updated the .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@ src/main/resources/docs/
 .DS_Store
 *.iml
 bin/
-.class
-.txt
+*.class
+*.txt
 ArrayList
+.project
+.settings/
+.classpath


### PR DESCRIPTION
fixed issue [https://github.com/AY1920S1-CS2113-T13-3/main/issues/6#issue-492144459]
there should be a "*" in front of ".txt" and ".class"