### PR TITLE
Enable users to unignore an ignored tasks.

### DIFF
--- a/src/main/java/command/IgnoreCommand.java
+++ b/src/main/java/command/IgnoreCommand.java
@@ -8,9 +8,11 @@ import ui.Ui;
 
 public class IgnoreCommand extends Command {
     private int indexOfTask;
+    private boolean isIgnore;
 
-    public IgnoreCommand(int index) {
+    public IgnoreCommand(int index, boolean isIgnore) {
         indexOfTask = index;
+        this.isIgnore = isIgnore;
     }
 
     @Override
@@ -20,8 +22,14 @@ public class IgnoreCommand extends Command {
             throw new DukeException(DukeException.taskDoesNotExist());
         }
 
-        Task task = tasks.markAsIgnorable(indexOfTask);
-        storage.saveFile(tasks.getTasks());
-        Ui.printOutput("Noted. This task has been marked as ignored:\n" + task.toString());
+        if (isIgnore) {
+            Task task = tasks.markAsIgnorable(indexOfTask);
+            storage.saveFile(tasks.getTasks());
+            Ui.printOutput("Noted. This task has been marked as ignored:\n" + task.toString());
+        } else {
+            Task task = tasks.markAsUnignorable(indexOfTask);
+            storage.saveFile(tasks.getTasks());
+            Ui.printOutput("Noted. This task is no longer ignored:\n" + task.toString());
+        }
     }
 }

--- a/src/main/java/parser/Parser.java
+++ b/src/main/java/parser/Parser.java
@@ -158,7 +158,9 @@ public class Parser {
             }
             return new SearchCommand(duration);
         case "ignore":
-            return parseIgnore(command, userInput);
+            return parseIgnore(userInput, true);
+        case "unignore":
+            return parseIgnore(userInput, false);
         default:
             // Empty string or unknown command.
             Ui.printUnknownInput();
@@ -295,9 +297,9 @@ public class Parser {
         return new AddCommand(command, taskDescription, fromDate, toDate);
     }
 
-    private static Command parseIgnore(String command, String userInput) {
+    private static Command parseIgnore(String userInput, Boolean isIgnore) {
         int index = Integer.parseInt(userInput.split("\\s+", 2)[1].trim()) - 1;
-        return new IgnoreCommand(index);
+        return new IgnoreCommand(index, isIgnore);
     }
 
     private static Command parseDuration(String userInput, String[] taskDetails, String checktype, String command)

--- a/src/main/java/task/Task.java
+++ b/src/main/java/task/Task.java
@@ -30,6 +30,7 @@ public abstract class Task implements Serializable {
 
     /**
      * Constructor for task.
+     *
      * @param description The description of the task
      */
     public Task(String description) {
@@ -100,6 +101,11 @@ public abstract class Task implements Serializable {
     public void markAsIgnorable() {
         this.isIgnored = true;
         this.isPrioritizable = false;
+    }
+
+    public void markAsUnignorable() {
+        this.isIgnored = false;
+        this.isPrioritizable = true;
     }
 
     public void markAsDone() {

--- a/src/main/java/task/TaskList.java
+++ b/src/main/java/task/TaskList.java
@@ -110,6 +110,18 @@ public class TaskList {
     }
 
     /**
+     * Marks a task to no longer be ignored and have reminders to show up again.
+     *
+     * @param index The index of the task to be marked
+     * @return The marked task
+     */
+    public Task markAsUnignorable(int index) {
+        Task task = listOfTasks.get(index);
+        task.markAsUnignorable();
+        return task;
+    }
+
+    /**
      * updates the timing of a particular task.
      *
      * @param taskToBeChanged task to be updated


### PR DESCRIPTION
Updated ignore command to take an additional boolean parameter to leverage on parseIgnore command for unignore purposes.
Include new method to unignore a task such that it can be prioritized and have reminders again. 