### PR TITLE
Fixed binding issues.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,8 +15,8 @@ checkstyle {
 
 dependencies {
     testImplementation 'org.junit.jupiter:junit-jupiter:5.5.0'
-    compile group: 'org.mnode.ical4j', name: 'ical4j', version: '3.0.6'
-
+    compile group: 'org.mnode.ical4j', name: 'ical4j', version: '3.0.11'
+    compile 'org.slf4j:slf4j-simple:1.7.21'
 }
 
 test {


### PR DESCRIPTION
Fix binding warning message due to missing logging dependency.
Now there will be a warning message: (ical4j.properties) not found the first time you use export.
It is just a once-per-run-info that the behavior of the lib can be configured (at least on non-android systems where the properties file can be outside the jar).
Export functionality will still work.